### PR TITLE
Remove versions of dependent gems in development

### DIFF
--- a/ydf.gemspec
+++ b/ydf.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
[OS Command Injection in Rake · CVE\-2020\-8130 · GitHub Advisory Database](https://github.com/advisories/GHSA-jppv-gw3r-w3q8)

> There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.